### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/src/plant_identification/router.py
+++ b/src/plant_identification/router.py
@@ -146,9 +146,10 @@ async def plant_identification_endpoint(
             )
 
     except PlantNotFoundError as e:
+        logger.error(f"Plant not found: {str(e)}")
         return JSONResponse(
             status_code=status.HTTP_404_NOT_FOUND,
-            content={"detail": str(e), "results": []}
+            content={"detail": "The requested plant could not be found.", "results": []}
         )
 
     except HTTPException:


### PR DESCRIPTION
Potential fix for [https://github.com/Progra-movil-umss/backend-/security/code-scanning/4](https://github.com/Progra-movil-umss/backend-/security/code-scanning/4)

To fix the issue, we will replace the direct inclusion of `str(e)` in the response with a generic error message. The specific details of the exception will be logged on the server for debugging purposes, but the user will only see a safe, generic message. This ensures that no sensitive information is exposed while still allowing developers to diagnose issues.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
