### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,4 +1,6 @@
 name: Add Issues to Projects
+permissions:
+  repository-projects: write
 on:
   issues:
     types: [ labeled ]


### PR DESCRIPTION
Potential fix for [https://github.com/Progra-movil-umss/backend-/security/code-scanning/3](https://github.com/Progra-movil-umss/backend-/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow file to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow interacts with GitHub projects, the minimal required permission is likely `repository-projects: write`. Other permissions should be set to `read` or omitted entirely if not needed.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to each job individually. In this case, adding it at the root level is more efficient since all jobs perform similar tasks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
